### PR TITLE
Hardset Python 3.9

### DIFF
--- a/apps/product_catalog/Dockerfile
+++ b/apps/product_catalog/Dockerfile
@@ -1,7 +1,11 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 # Use an official Python runtime as an image
-FROM python:3
+FROM python:3.9-slim
+
+RUN apt-get update \
+    && apt-get install curl -y \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
The official `python:3` image now points to python 3.10. This appears to break the application as you receive `ImportError: cannot import name 'Hashable' from 'collections'` errors when the container starts.

This PR hard sets the python version to 3.9 where Hashable can still be find in the collections package. I have also switched to the slim variant of the image to speed up Fargate boot times. The downside of using the slim variant is that curl is not installed by default. As the workshop makes use of the curl command I've added that back in with apt. Previous compressed image size 383.89mb, new compressed  image size 80.61mb.