### PR TITLE
Update requirements.txt

### DIFF
--- a/workshop/apps/product_catalog/requirements.txt
+++ b/workshop/apps/product_catalog/requirements.txt
@@ -1,5 +1,6 @@
 flask-restplus==0.12.1
-flask==1.0.3
+flask==1.1.4
+markupsafe==2.0.1
 werkzeug==1.0.1
 gunicorn==20.0.4
 requests==v2.24.0


### PR DESCRIPTION
As per https://github.com/aws-samples/amazon-ecs-mythicalmysfits-workshop/issues/49, flask version needs an update (1.0.3 to 1.1.4) to avoid running into below error:
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/local/lib/python3.8/dist-packages/itsdangerous/__init__.py)