### PR TITLE
Pin mysql version - 5.7.38 misses hostname cli command

### DIFF
--- a/workshop/mysql-statefulset.yaml
+++ b/workshop/mysql-statefulset.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       initContainers:
       - name: init-mysql
-        image: mysql:5.7
+        image: mysql:5.7.37
         command:
         - bash
         - "-c"
@@ -64,7 +64,7 @@ spec:
           mountPath: /etc/mysql/conf.d
       containers:
       - name: mysql
-        image: mysql:5.7
+        image: mysql:5.7.37
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "1"


### PR DESCRIPTION
This PR pins the mysql version to 5.7.37. In 5.7.38 which is pulled automatically using version 5.7 the hostname CLI command is missing, which leads to the pod ending in an infinite crash loop.