### PR TITLE
fixed hostname (command not found) failure in init-mysql stateful sets

### DIFF
--- a/workshop/mysql-statefulset.yaml
+++ b/workshop/mysql-statefulset.yaml
@@ -23,7 +23,8 @@ spec:
         - |
           set -ex
           # Generate mysql server-id from pod ordinal index.
-          [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+          hostname=$(hostname) || hostname=$(cat /etc/hostname)
+          [[ $hostname =~ -([0-9]+)$ ]] || exit 1
           ordinal=${BASH_REMATCH[1]}
           echo [mysqld] > /mnt/conf.d/server-id.cnf
           # Add an offset to avoid reserved server-id=0 value.


### PR DESCRIPTION
Our workshop class (everyone) ran into the following issue during Stateful sets deployment, which was a showstopper: 

**The Issue**:  mysql-0 failed to deploy due to an issue in init-mysql, as seen in the logs for this init container : 
```
$ kubectl -n workshop logs mysql-0  -c init-mysql
++ hostname
bash: line 2: hostname: command not found
```

**The fix**: I changed to this version you see. Essentially if the (current) `hostname` command fails, then it tries the next best thing:  `cat /etc/hostname` .  This worked like a charm, as seen in subsequent logs: 
```
$ kubectl -n workshop logs mysql-0  -c init-mysql
++ hostname
bash: line 2: hostname: command not found
+ hostname=
++ cat /etc/hostname
+ hostname=mysql-0
+ [[ mysql-0 =~ -([0-9]+)$ ]]
+ ordinal=0
+ echo '[mysqld]'
+ echo server-id=100
+ [[ 0 -eq 0 ]]
+ cp /mnt/config-map/master.cnf /mnt/conf.d/
```

As seen above, despite the failed hostname command, the second option succeeded and the stateful sets pods (mysql-0 and mysql-1) get created successfully
