### PR TITLE
Aligning the Fargate Profile with EKS Immersion Day content

### DIFF
--- a/deployment/clusterconfig.yaml
+++ b/deployment/clusterconfig.yaml
@@ -9,6 +9,6 @@ metadata:
 fargateProfiles:
   - name: fargate-productcatalog
     selectors:
-      - namespace: prodcatalog-ns
+      - namespace: workshop
         labels:
           app: prodcatalog


### PR DESCRIPTION
Aligning the Fargate Profile with https://catalog.workshops.aws/eks-immersionday/en-US/fargate/fargate

In the current state, pods are not re-scheduled on Fargate because they use a different pod selector in the Fargate profile.