### PR TITLE
fixing the fargate profile namespace

### DIFF
--- a/deployment/clusterconfig.yaml
+++ b/deployment/clusterconfig.yaml
@@ -9,6 +9,6 @@ metadata:
 fargateProfiles:
   - name: fargate-productcatalog
     selectors:
-      - namespace: workshop
+      - namespace: prodcatalog-ns
         labels:
           app: prodcatalog


### PR DESCRIPTION
As discussed, changing the namespace in the fargate profile to align with the namespace created for application as per the instructions https://www.eksworkshop.com/advanced/330_servicemesh_using_appmesh/add_nodegroup_fargate/create_fargate/.

This should not cause a conflict with the fargate lab in EKS immersion day as this fargate profile is not used there -- the profile is copied/pasted from the instructions instead.