### PR TITLE
feat: xRay auto-instrumentation with opentelemetry

### DIFF
--- a/apps/product_catalog/Dockerfile
+++ b/apps/product_catalog/Dockerfile
@@ -14,10 +14,17 @@ WORKDIR /app
 COPY requirements.txt /app
 RUN pip install -r requirements.txt
 
+RUN opentelemetry-bootstrap --action=install
+
 COPY . /app
 
 # ENV AGG_APP_URL='http://prodinfo.octank-mesh-ns.svc.cluster.local:3000/productAgreement'
 
 #WORKDIR /docker_app
 EXPOSE 8080
-ENTRYPOINT ["/app/bootstrap.sh"]
+CMD opentelemetry-instrument \
+    # --traces_exporter=console \
+    --log_level=debug \
+    # --logs_exporter=console \
+    # --metrics_exporter=none \
+    python3 -m flask run -h 0.0.0.0

--- a/apps/product_catalog/app.py
+++ b/apps/product_catalog/app.py
@@ -8,10 +8,10 @@ from flask_cors import CORS
 import requests
 import os
 import logging
-from aws_xray_sdk.core import xray_recorder
-from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
-xray_recorder.configure(context_missing='LOG_ERROR')
-from aws_xray_sdk.core import patch_all
+# from aws_xray_sdk.core import xray_recorder
+# from aws_xray_sdk.ext.flask.middleware import XRayMiddleware
+# xray_recorder.configure(context_missing='LOG_ERROR')
+# from aws_xray_sdk.core import patch_all
 
 flask_app = Flask(__name__)
 flask_app.debug = True
@@ -21,8 +21,8 @@ flask_app.logger.setLevel(log_level)
 CORS(flask_app, resources={r'/*': {'origins': '*'}})
 
 #configure SDK code
-xray_recorder.configure(service='Product-Catalog')
-XRayMiddleware(flask_app, xray_recorder)
+# xray_recorder.configure(service='Product-Catalog')
+# XRayMiddleware(flask_app, xray_recorder)
 
 AGG_APP_URL = os.environ.get("AGG_APP_URL")
 
@@ -130,4 +130,4 @@ class MainClass(Resource):
             name_space.abort(400, e.__doc__, status = "Could not save information", statusCode = "400")
 
 if __name__ == '__main__':
-    app.run(host="0.0.0.0", debug=True)
+    app.run(host="0.0.0.0", debug=True, use_reloader=False)

--- a/apps/product_catalog/requirements.txt
+++ b/apps/product_catalog/requirements.txt
@@ -7,3 +7,6 @@ aws-xray-sdk==2.6.0
 flask-cors==3.0.0
 boto3==1.9.22
 markupsafe==2.0.1
+opentelemetry-distro[otlp]
+opentelemetry-sdk-extension-aws
+opentelemetry-propagator-aws-xray

--- a/deployment/base_app.yaml
+++ b/deployment/base_app.yaml
@@ -127,6 +127,8 @@ spec:
     metadata:
       labels:
         app: prodcatalog
+      annotations:
+        sidecar.opentelemetry.io/inject: "true"
     spec:
       serviceAccountName: prodcatalog-envoy-proxies
       containers:
@@ -136,6 +138,14 @@ spec:
           env:
             - name: AGG_APP_URL
               value: "http://proddetail.prodcatalog-ns.svc.cluster.local:3000/catalogDetail"
+            - name: AWS_REGION
+              value: "${AWS_REGION}"
+            - name: OTEL_PROPAGATORS
+              value: xray
+            - name: OTEL_PYTHON_ID_GENERATOR
+              value: xray
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.namespace=eks-app-mesh-demo,service.name=prodcatalog
           livenessProbe:
             httpGet:
               path: /products/ping

--- a/workshop/collector-config-opentelemetry.yaml
+++ b/workshop/collector-config-opentelemetry.yaml
@@ -1,0 +1,52 @@
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: my-collector-xray
+  namespace: prodcatalog-ns
+spec:
+  mode: sidecar
+  resources:
+    requests:
+      cpu: "1"
+    limits:
+      cpu: "1"
+  serviceAccount: adot-collector
+  image: public.ecr.aws/aws-observability/aws-otel-collector:latest
+  config: |
+    extensions:
+      health_check:
+      pprof:
+        endpoint: 0.0.0.0:1777
+    
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    
+    processors:
+      batch:
+    
+    exporters:
+      logging:
+        loglevel: debug
+      awsxray:
+        region: 'us-east-2'
+      awsemf:
+        region: 'us-east-2'
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [awsxray, logging]
+        metrics:
+          receivers: [otlp]
+          exporters: [awsemf, logging]
+    
+      extensions: [pprof]
+      telemetry:
+        logs:
+          level: debug

--- a/workshop/collector-config-opentelemetry.yaml
+++ b/workshop/collector-config-opentelemetry.yaml
@@ -33,9 +33,9 @@ spec:
       logging:
         loglevel: debug
       awsxray:
-        region: 'us-east-2'
+        region: ${AWS_REGION}
       awsemf:
-        region: 'us-east-2'
+        region: ${AWS_REGION}
     
     service:
       pipelines:


### PR DESCRIPTION
As discussed, I've auto-instrumented the prodcatalog python app with opentelemetry. The collector receives the traces and forwards them to xRay service.

**Summary**
- bb6d0d3 [autoinstrumentation]: Changed collector-config-opentelemetry.yaml to set the region based on the AWS_REGION environment variable
- af77378 [autoinstrumentation]: Changed requirements.txt to include opentelemetry modules
- 2ba2374 [autoinstrumentation]: Changed Dockerfile to run opentelemetry-bootstrap and to start container with opentelemetry-instrument
- 6cb4357 [autoinstrumentation]: Changed app.py to disable xray and flask auto reloader
- 2da33e3 [autoinstrumentation]: Changed base_app.yaml to include opentelemetry environment variables
- 487c12a [autoinstrumentation]: Included collector-config-opentelemetry.yaml that needs to be deployed to enable opentelemetry collector as sidecar