### PR TITLE
fix: update statefulset in secrets chapter to use mysql-gp2 storage class

### DIFF
--- a/workshop/mysql-statefulset-with-secret.yaml
+++ b/workshop/mysql-statefulset-with-secret.yaml
@@ -191,6 +191,7 @@ spec:
         name: data
       spec:
         accessModes: ["ReadWriteOnce"]
+        storageClassName: mysql-gp2
         resources:
           requests:
             storage: 10Gi


### PR DESCRIPTION
This PR updates statefulset in secrets chapter to use mysql-gp2 storage class. This change is aligned to the eks immersion day secrets chapter updates related to eks 1.24.