### PR TITLE
fix: Adding missing `values-psa-pss-restricted-ns.yaml` file.

### DIFF
--- a/workshop/helm-chart/security/values-psa-pss-restricted-ns.yaml
+++ b/workshop/helm-chart/security/values-psa-pss-restricted-ns.yaml
@@ -1,0 +1,8 @@
+# Default values for helm-chart.
+namespace:
+  security:
+    enabled: true
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
### What does this PR do?

* Add a the Restricted PSS configuration for the `workshop` Namespace that was missing.
  * `workshop/helm-charts/security/values-psa-pss-restricted-ns.yaml`

```yaml
namespace:
  security:
    enabled: true
  labels:
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/enforce: restricted
    pod-security.kubernetes.io/warn: restricted
```