### PR TITLE
Removed Ingress Class

### DIFF
--- a/workshop/apps/sku/helm-chart/templates/ingress.yaml
+++ b/workshop/apps/sku/helm-chart/templates/ingress.yaml
@@ -15,7 +15,6 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: aws-alb
 {{- if .Values.sku.ingress.tls }}
   tls:
   {{- range .Values.sku.ingress.tls }}


### PR DESCRIPTION
Removed ingress class from SKU app helm chart now automatically inherits the ingress requests as the AWS Load Balancer Controller will come as built in with the new build version