### PR TITLE
Add annotations for scheme and target-type

### DIFF
--- a/deployment/virtual_gateway.yaml
+++ b/deployment/virtual_gateway.yaml
@@ -42,6 +42,8 @@ metadata:
   namespace: prodcatalog-ns
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
**Issue:** Fixes #41

**Description**: Add annotations to Virtual Gateway service to create internet facing NLB and set target type to ip.